### PR TITLE
Add explicit loading of cc_rules

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 config_setting(
 	name = "windows",
 	values = {


### PR DESCRIPTION
Buildifier complains:
Function "cc_library" is not global anymore and needs to be loaded from "@rules_cc//cc:defs.bzl".