### PR TITLE
(master) Fixes missing src glob in hidapi

### DIFF
--- a/src/hidapi/BUILD.bazel
+++ b/src/hidapi/BUILD.bazel
@@ -13,7 +13,7 @@ cc_library(
 		"//:macos": glob(
 			["*.c"],
 		),
-		"//conditions:default": ["*.c"],
+		"//conditions:default": glob(["*.c"]),
 	}),
 	deps = ["//:SDL2internal"] + select({
 		"//:windows": [


### PR DESCRIPTION
- for default configuration, affecting linux build
- "bazel build //:libSDL2.so" would not build without this