### PR TITLE
Remove extra colon from Windows README.md usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,5 @@ There are several targets for getting a shared library of SDL2
 # Linux
 @bazelregistry_sdl2//:libSDL2.so
 # Windows
-@bazelregistry_sdl2//::SDL2.dll
+@bazelregistry_sdl2//:SDL2.dll
 ```


### PR DESCRIPTION
## Description
Correcting error:
invalid label '@bazelregistry_sdl2//::SDL2.dll' in element 2 of attribute 'deps' in 'cc_library' rule: invalid target name ':SDL2.dll': target names may not contain ':'
